### PR TITLE
Added preconfigured enable password for TACACS+ users

### DIFF
--- a/aaa/tac_plus.conf
+++ b/aaa/tac_plus.conf
@@ -63,7 +63,8 @@ user = gns3 {
     name = "Admin User"
     member = admin
     login = des AxKP5aUynXxrg
-		service = junos-exec {
+    enable = des AxKP5aUynXxrg
+	service = junos-exec {
 			local-user-name = remote-admin
 	}
 }
@@ -72,6 +73,7 @@ user = readonly {
     name = "R/O User"
     member = read-only
     login =  des AxKP5aUynXxrg
+    enable = des AxKP5aUynXxrg
         service = junos-exec {
             local-user-name = remote-read-only
                }


### PR DESCRIPTION
It's required for successful authorization of users with enable command.
enable = 'gns3'